### PR TITLE
feat: Refactor AI tagging system to support multiple providers and enhance settings

### DIFF
--- a/app/src/androidTest/java/io/github/patricksmill/quicknotes/model/tag/TagSettingsManagerTest.kt
+++ b/app/src/androidTest/java/io/github/patricksmill/quicknotes/model/tag/TagSettingsManagerTest.kt
@@ -1,0 +1,90 @@
+package io.github.patricksmill.quicknotes.model.tag
+
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class TagSettingsManagerTest {
+    private val context = InstrumentationRegistry.getInstrumentation()
+        .targetContext.applicationContext
+
+    @Before
+    fun setUp() {
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    @Test
+    fun providerSpecificValuesPersistIndependently() {
+        val settings = TagSettingsManager(context)
+
+        settings.setSelectedProvider(TagSettingsManager.AiProvider.OPENAI)
+        settings.saveApiKey("openai-key")
+        settings.saveModel(TagSettingsManager.AiProvider.OPENAI, "gpt-openai")
+
+        settings.setSelectedProvider(TagSettingsManager.AiProvider.ANTHROPIC)
+        settings.saveApiKey("claude-key")
+        settings.saveModel(TagSettingsManager.AiProvider.ANTHROPIC, "claude-model")
+
+        settings.setSelectedProvider(TagSettingsManager.AiProvider.GOOGLE)
+        settings.saveApiKey("google-key")
+        settings.saveModel(TagSettingsManager.AiProvider.GOOGLE, "gemini-model")
+
+        settings.setSelectedProvider(TagSettingsManager.AiProvider.CUSTOM)
+        settings.saveApiKey("custom-key")
+        settings.saveCustomBaseUrl("https://example.com/v1")
+        settings.saveModel(TagSettingsManager.AiProvider.CUSTOM, "custom-model")
+
+        val reloaded = TagSettingsManager(context)
+
+        assertEquals("openai-key", reloaded.apiKeyFor(TagSettingsManager.AiProvider.OPENAI))
+        assertEquals("gpt-openai", reloaded.modelFor(TagSettingsManager.AiProvider.OPENAI))
+        assertEquals("claude-key", reloaded.apiKeyFor(TagSettingsManager.AiProvider.ANTHROPIC))
+        assertEquals("claude-model", reloaded.modelFor(TagSettingsManager.AiProvider.ANTHROPIC))
+        assertEquals("google-key", reloaded.apiKeyFor(TagSettingsManager.AiProvider.GOOGLE))
+        assertEquals("gemini-model", reloaded.modelFor(TagSettingsManager.AiProvider.GOOGLE))
+        assertEquals("custom-key", reloaded.apiKeyFor(TagSettingsManager.AiProvider.CUSTOM))
+        assertEquals("https://example.com/v1", reloaded.endpointFor(TagSettingsManager.AiProvider.CUSTOM))
+        assertEquals("custom-model", reloaded.modelFor(TagSettingsManager.AiProvider.CUSTOM))
+    }
+
+    @Test
+    fun legacyCustomEndpointPromotesCustomProvider() {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        prefs.edit()
+            .putString("openai_api_base_url", "https://example.com/v1")
+            .putString("pref_ai_model", "legacy-model")
+            .commit()
+
+        val settings = TagSettingsManager(context)
+
+        assertEquals(TagSettingsManager.AiProvider.CUSTOM, settings.selectedProvider)
+        assertEquals("https://example.com/v1", settings.selectedAiEndpoint)
+        assertEquals("legacy-model", settings.selectedAiModelKey)
+    }
+
+    @Test
+    fun defaultModelsAreProviderAppropriate() {
+        val settings = TagSettingsManager(context)
+
+        assertEquals("gpt-5-mini", settings.modelFor(TagSettingsManager.AiProvider.OPENAI))
+        assertEquals("claude-sonnet-4-20250514", settings.modelFor(TagSettingsManager.AiProvider.ANTHROPIC))
+        assertEquals("gemini-2.5-flash", settings.modelFor(TagSettingsManager.AiProvider.GOOGLE))
+        assertEquals("gpt-5-mini", settings.modelFor(TagSettingsManager.AiProvider.CUSTOM))
+    }
+
+    private fun clearPrefs() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .clear()
+            .commit()
+    }
+}

--- a/app/src/androidTest/java/io/github/patricksmill/quicknotes/view/SettingsFragmentTest.kt
+++ b/app/src/androidTest/java/io/github/patricksmill/quicknotes/view/SettingsFragmentTest.kt
@@ -12,11 +12,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-/**
- * Instrumentation test for the SettingsFragment and TagColorSettingsFragment
- * This class tests the functionality of the settings screens,
- * including preference navigation and dialog interactions.
- */
 class SettingsFragmentTest {
     @Rule
     var activityRule: ActivityScenarioRule<ControllerActivity?> =
@@ -24,101 +19,90 @@ class SettingsFragmentTest {
 
     @Before
     fun setUp() {
-        val ctx = InstrumentationRegistry
-            .getInstrumentation()
-            .targetContext
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
         ctx.deleteFile("notes.json")
         navigateToSettings()
     }
 
-    /**
-     * Helper method to navigate to the settings screen
-     */
     private fun navigateToSettings() {
         Espresso.onView(ViewMatchers.withId(R.id.settingsButton))
             .perform(ViewActions.click())
     }
 
+    private fun selectProvider(name: String) {
+        Espresso.onView(ViewMatchers.withText("AI Provider"))
+            .perform(ViewActions.click())
+        Espresso.onView(ViewMatchers.withText(name))
+            .perform(ViewActions.click())
+    }
 
-    /**
-     * Test that the settings screen displays correctly
-     */
     @Test
     fun testSettingsDisplayed() {
+        Espresso.onView(ViewMatchers.withText("AI Provider"))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
         Espresso.onView(ViewMatchers.withText("OpenAI API Key"))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
+        Espresso.onView(ViewMatchers.withText("Model Library"))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
+        Espresso.onView(ViewMatchers.withText("OpenAI Model"))
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
 
         Espresso.onView(ViewMatchers.withText("Auto-Tag Limit"))
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
 
-        Espresso.onView(ViewMatchers.withText("Allow Notifications"))
+        Espresso.onView(ViewMatchers.withText("Manage notifications"))
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
 
         Espresso.onView(ViewMatchers.withText("Delete All Notes"))
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    }
 
-        Espresso.onView(ViewMatchers.withText("Edit Tag Colors"))
+    @Test
+    fun testSwitchToClaudeUpdatesFields() {
+        selectProvider("Claude")
+
+        Espresso.onView(ViewMatchers.withText("Claude API Key"))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
+        Espresso.onView(ViewMatchers.withText("Claude Model"))
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
     }
 
-    /**
-     * Test that clicking on the OpenAI API key preference opens a dialog
-     */
     @Test
-    fun testOpenApiKeyClick() {
+    fun testSwitchToCustomShowsEndpointField() {
+        selectProvider("Custom")
+
+        Espresso.onView(ViewMatchers.withText("Custom API Key"))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
+        Espresso.onView(ViewMatchers.withText("Custom API Base URL"))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    }
+
+    @Test
+    fun testModelLibraryShowsCuratedModels() {
+        Espresso.onView(ViewMatchers.withText("Model Library"))
+            .perform(ViewActions.click())
+
+        Espresso.onView(ViewMatchers.withText("GPT-5 mini"))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
+        Espresso.onView(ViewMatchers.withText("GPT-5.2"))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
+        Espresso.onView(ViewMatchers.withText("GPT-4.1"))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    }
+
+    @Test
+    fun testOpenApiProviderTitleIsShownInitially() {
         Espresso.onView(ViewMatchers.withText("OpenAI API Key"))
-            .perform(ViewActions.click())
-
-        Espresso.onView(ViewMatchers.withText("OpenAI API Key"))
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
 
-        Espresso.onView(ViewMatchers.withText("Cancel"))
-            .perform(ViewActions.click())
-    }
-
-    /**
-     * Test that clicking on the Delete All Notes preference shows a confirmation dialog
-     */
-    @Test
-    fun testDeleteAllNotesDialog() {
-        Espresso.onView(ViewMatchers.withText("Delete All Notes"))
-            .perform(ViewActions.click())
-
-        Espresso.onView(ViewMatchers.withText("Delete All Notes"))
-            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
-
-        Espresso.onView(ViewMatchers.withText("Are you sure? This will permanently erase all your notes."))
-            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
-
-        Espresso.onView(ViewMatchers.withText("Cancel"))
-            .perform(ViewActions.click())
-    }
-
-    /**
-     * Test toggling AI mode preference
-     */
-    @Test
-    fun testToggleAiMode() {
-        Espresso.onView(ViewMatchers.withText("Use AI-powered Auto-Tagging"))
-            .perform(ViewActions.click())
-
-        Espresso.onView(ViewMatchers.withText("Use AI-powered Auto-Tagging"))
-            .perform(ViewActions.click())
-    }
-
-    /**
-     * Test navigation to Tag Color Settings screen
-     */
-    @Test
-    fun testNavigateToTagColorSettings() {
-        Espresso.onView(ViewMatchers.withText("Edit Tag Colors"))
-            .perform(ViewActions.click())
-
-        Espresso.onView(ViewMatchers.withText("No tags available"))
-            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
-
-        Espresso.pressBack()
-        Espresso.onView(ViewMatchers.withText("AI"))
+        Espresso.onView(ViewMatchers.withText("OpenAI Model"))
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
     }
 }

--- a/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/AiModelCatalog.kt
+++ b/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/AiModelCatalog.kt
@@ -6,10 +6,8 @@ import android.net.Uri
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import com.google.gson.JsonParser
-import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
-import java.nio.charset.StandardCharsets
 import java.util.Locale
 
 /**
@@ -275,18 +273,6 @@ class AiModelCatalog(context: Context) {
         } finally {
             connection.disconnect()
         }
-    }
-
-    private fun readBody(connection: HttpURLConnection, code: Int): String {
-        val stream = if (code in 200..299) connection.inputStream else connection.errorStream
-        if (stream == null) return ""
-        return InputStreamReader(stream, StandardCharsets.UTF_8).use { it.readText() }
-    }
-
-    private fun joinUrl(baseUrl: String, path: String): String {
-        val trimmed = baseUrl.trim().trimEnd('/')
-        val suffix = path.trimStart('/')
-        return "$trimmed/$suffix"
     }
 
     companion object {

--- a/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/AiModelCatalog.kt
+++ b/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/AiModelCatalog.kt
@@ -1,0 +1,310 @@
+package io.github.patricksmill.quicknotes.model.tag
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.Uri
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import com.google.gson.JsonParser
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+
+/**
+ * Curates model suggestions for the selected AI provider.
+ *
+ * The goal is to always show a sensible local shortlist and optionally enrich it with live API
+ * results when the user chooses to refresh.
+ */
+class AiModelCatalog(context: Context) {
+    private val preferences: SharedPreferences =
+        PreferenceManager.getDefaultSharedPreferences(context.applicationContext)
+
+    data class ModelOption(
+        val id: String,
+        val label: String
+    )
+
+    fun curatedSuggestions(provider: TagSettingsManager.AiProvider): List<ModelOption> {
+        return when (provider) {
+            TagSettingsManager.AiProvider.OPENAI -> listOf(
+                ModelOption("gpt-5-mini", "GPT-5 mini"),
+                ModelOption("gpt-5.2", "GPT-5.2"),
+                ModelOption("gpt-4.1", "GPT-4.1"),
+                ModelOption("gpt-4o-mini", "GPT-4o mini")
+            )
+
+            TagSettingsManager.AiProvider.ANTHROPIC -> listOf(
+                ModelOption("claude-sonnet-4-20250514", "Claude Sonnet 4"),
+                ModelOption("claude-opus-4-1-20250805", "Claude Opus 4.1"),
+                ModelOption("claude-3-7-sonnet-20250219", "Claude Sonnet 3.7"),
+                ModelOption("claude-3-5-haiku-20241022", "Claude Haiku 3.5")
+            )
+
+            TagSettingsManager.AiProvider.GOOGLE -> listOf(
+                ModelOption("gemini-2.5-flash", "Gemini 2.5 Flash"),
+                ModelOption("gemini-2.5-pro", "Gemini 2.5 Pro"),
+                ModelOption("gemini-2.5-flash-lite", "Gemini 2.5 Flash-Lite"),
+                ModelOption("gemini-2.0-flash-lite", "Gemini 2.0 Flash-Lite")
+            )
+
+            TagSettingsManager.AiProvider.CUSTOM -> emptyList()
+        }
+    }
+
+    fun cachedSuggestions(provider: TagSettingsManager.AiProvider): List<ModelOption> {
+        return readCachedSuggestions(provider)
+    }
+
+    fun saveCachedSuggestions(
+        provider: TagSettingsManager.AiProvider,
+        suggestions: List<ModelOption>
+    ) {
+        val normalized = normalizeSuggestions(suggestions)
+        if (normalized.isEmpty()) {
+            preferences.edit { remove(cacheKey(provider)) }
+            return
+        }
+        preferences.edit { putString(cacheKey(provider), buildJson(normalized)) }
+    }
+
+    fun fetchSuggestions(
+        provider: TagSettingsManager.AiProvider,
+        endpoint: String,
+        apiKey: String?
+    ): List<ModelOption> {
+        val effectiveKey = apiKey?.trim().orEmpty()
+        val response = when (provider) {
+            TagSettingsManager.AiProvider.OPENAI,
+            TagSettingsManager.AiProvider.CUSTOM -> {
+                require(effectiveKey.isNotBlank()) { "Missing API key for ${provider.displayName}" }
+                getJson(
+                    url = joinUrl(endpoint, "models"),
+                    headers = mapOf("Authorization" to "Bearer $effectiveKey")
+                )
+            }
+
+            TagSettingsManager.AiProvider.ANTHROPIC -> {
+                require(effectiveKey.isNotBlank()) { "Missing API key for ${provider.displayName}" }
+                getJson(
+                    url = joinUrl(endpoint, "models"),
+                    headers = mapOf(
+                        "x-api-key" to effectiveKey,
+                        "anthropic-version" to "2023-06-01"
+                    )
+                )
+            }
+
+            TagSettingsManager.AiProvider.GOOGLE -> {
+                require(effectiveKey.isNotBlank()) { "Missing API key for ${provider.displayName}" }
+                val url = Uri.parse(GOOGLE_MODELS_ENDPOINT)
+                    .buildUpon()
+                    .appendQueryParameter("key", effectiveKey)
+                    .build()
+                    .toString()
+                getJson(url = url, headers = emptyMap())
+            }
+        }
+
+        return when (provider) {
+            TagSettingsManager.AiProvider.OPENAI,
+            TagSettingsManager.AiProvider.CUSTOM -> parseOpenAiModels(response)
+
+            TagSettingsManager.AiProvider.ANTHROPIC -> parseAnthropicModels(response)
+            TagSettingsManager.AiProvider.GOOGLE -> parseGoogleModels(response)
+        }
+    }
+
+    fun mergedSuggestions(
+        provider: TagSettingsManager.AiProvider,
+        currentModel: String,
+        liveSuggestions: List<ModelOption>? = null
+    ): List<ModelOption> {
+        val ordered = linkedMapOf<String, ModelOption>()
+
+        fun addAll(options: List<ModelOption>) {
+            options.forEach { option ->
+                val id = option.id.trim()
+                if (id.isBlank()) return@forEach
+                ordered.putIfAbsent(
+                    id.lowercase(Locale.US),
+                    ModelOption(id = id, label = option.label.trim().ifBlank { id })
+                )
+            }
+        }
+
+        addAll(curatedSuggestions(provider))
+        addAll(if (liveSuggestions.isNullOrEmpty()) cachedSuggestions(provider) else liveSuggestions)
+
+        val current = currentModel.trim()
+        if (current.isNotBlank()) {
+            ordered.putIfAbsent(
+                current.lowercase(Locale.US),
+                ModelOption(id = current, label = "Current selection: $current")
+            )
+        }
+
+        val defaultModel = provider.defaultModel.trim()
+        if (defaultModel.isNotBlank()) {
+            ordered.putIfAbsent(
+                defaultModel.lowercase(Locale.US),
+                ModelOption(id = defaultModel, label = "Suggested default: $defaultModel")
+            )
+        }
+
+        return ordered.values.toList()
+    }
+
+    private fun normalizeSuggestions(suggestions: List<ModelOption>): List<ModelOption> {
+        return suggestions
+            .mapNotNull { option ->
+                val id = option.id.trim()
+                if (id.isBlank()) return@mapNotNull null
+                ModelOption(id = id, label = option.label.trim().ifBlank { id })
+            }
+            .distinctBy { it.id.lowercase(Locale.US) }
+            .sortedBy { it.label.lowercase(Locale.US) }
+    }
+
+    private fun buildJson(suggestions: List<ModelOption>): String {
+        return suggestions.joinToString(prefix = "[", postfix = "]") { option ->
+            """{"id":"${escapeJson(option.id)}","label":"${escapeJson(option.label)}"}"""
+        }
+    }
+
+    private fun escapeJson(value: String): String {
+        return buildString(value.length) {
+            value.forEach { ch ->
+                when (ch) {
+                    '\\' -> append("\\\\")
+                    '"' -> append("\\\"")
+                    '\b' -> append("\\b")
+                    '\u000C' -> append("\\f")
+                    '\n' -> append("\\n")
+                    '\r' -> append("\\r")
+                    '\t' -> append("\\t")
+                    else -> append(ch)
+                }
+            }
+        }
+    }
+
+    private fun readCachedSuggestions(provider: TagSettingsManager.AiProvider): List<ModelOption> {
+        val raw = preferences.getString(cacheKey(provider), null).orEmpty()
+        if (raw.isBlank()) return emptyList()
+
+        return try {
+            val parsed = JsonParser.parseString(raw).asJsonArray
+            parsed.mapNotNull { element ->
+                val obj = element.asJsonObject
+                val id = obj.get("id")?.asString.orEmpty().trim()
+                if (id.isBlank()) return@mapNotNull null
+                val label = obj.get("label")?.asString.orEmpty().trim().ifBlank { id }
+                ModelOption(id = id, label = label)
+            }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun parseOpenAiModels(response: com.google.gson.JsonObject): List<ModelOption> {
+        val data = response.getAsJsonArray("data") ?: return emptyList()
+        return data.mapNotNull { element ->
+            val obj = element.asJsonObject
+            val id = obj.get("id")?.asString.orEmpty().trim()
+            if (id.isBlank()) null else ModelOption(id = id, label = prettifyModelLabel(id))
+        }
+    }
+
+    private fun parseAnthropicModels(response: com.google.gson.JsonObject): List<ModelOption> {
+        val data = response.getAsJsonArray("data") ?: return emptyList()
+        return data.mapNotNull { element ->
+            val obj = element.asJsonObject
+            val id = obj.get("id")?.asString.orEmpty().trim()
+            if (id.isBlank()) return@mapNotNull null
+            val label = obj.get("display_name")?.asString.orEmpty().trim().ifBlank { prettifyModelLabel(id) }
+            ModelOption(id = id, label = label)
+        }
+    }
+
+    private fun parseGoogleModels(response: com.google.gson.JsonObject): List<ModelOption> {
+        val models = response.getAsJsonArray("models") ?: return emptyList()
+        return models.mapNotNull { element ->
+            val obj = element.asJsonObject
+            val name = obj.get("name")?.asString.orEmpty().trim()
+            val id = name.substringAfterLast('/').ifBlank { obj.get("id")?.asString.orEmpty().trim() }
+            if (id.isBlank() || !id.startsWith("gemini-", ignoreCase = true)) return@mapNotNull null
+            val label = obj.get("displayName")?.asString.orEmpty().trim().ifBlank { prettifyModelLabel(id) }
+            ModelOption(id = id, label = label)
+        }
+    }
+
+    private fun prettifyModelLabel(id: String): String {
+        return when {
+            id.startsWith("gpt-", ignoreCase = true) ->
+                id.replace("gpt-", "GPT-").replace("-mini", " mini").replace("-nano", " nano")
+
+            id.startsWith("claude-", ignoreCase = true) ->
+                id.replace("claude-", "Claude ").replace("-", " ")
+
+            id.startsWith("gemini-", ignoreCase = true) ->
+                id.replace("gemini-", "Gemini ").replace("-", " ")
+
+            else -> id
+        }
+    }
+
+    private fun getJson(url: String, headers: Map<String, String>): com.google.gson.JsonObject {
+        val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            connectTimeout = 30_000
+            readTimeout = 30_000
+            doInput = true
+            headers.forEach { (name, value) -> setRequestProperty(name, value) }
+        }
+
+        try {
+            val code = connection.responseCode
+            val body = readBody(connection, code)
+            if (code !in 200..299) {
+                throw IllegalStateException("HTTP $code ${connection.responseMessage}: $body")
+            }
+            return JsonParser.parseString(body).asJsonObject
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun readBody(connection: HttpURLConnection, code: Int): String {
+        val stream = if (code in 200..299) connection.inputStream else connection.errorStream
+        if (stream == null) return ""
+        return InputStreamReader(stream, StandardCharsets.UTF_8).use { it.readText() }
+    }
+
+    private fun joinUrl(baseUrl: String, path: String): String {
+        val trimmed = baseUrl.trim().trimEnd('/')
+        val suffix = path.trimStart('/')
+        return "$trimmed/$suffix"
+    }
+
+    companion object {
+        fun cacheKey(provider: TagSettingsManager.AiProvider): String {
+            return when (provider) {
+                TagSettingsManager.AiProvider.OPENAI -> OPENAI_CACHE_KEY
+                TagSettingsManager.AiProvider.ANTHROPIC -> ANTHROPIC_CACHE_KEY
+                TagSettingsManager.AiProvider.GOOGLE -> GOOGLE_CACHE_KEY
+                TagSettingsManager.AiProvider.CUSTOM -> CUSTOM_CACHE_KEY
+            }
+        }
+
+        private const val GOOGLE_MODELS_ENDPOINT =
+            "https://generativelanguage.googleapis.com/v1beta/models"
+
+        private const val OPENAI_CACHE_KEY = "ai_model_suggestions_openai"
+        private const val ANTHROPIC_CACHE_KEY = "ai_model_suggestions_anthropic"
+        private const val GOOGLE_CACHE_KEY = "ai_model_suggestions_google"
+        private const val CUSTOM_CACHE_KEY = "ai_model_suggestions_custom"
+    }
+}

--- a/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/AutoTaggingService.kt
+++ b/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/AutoTaggingService.kt
@@ -5,11 +5,14 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.widget.Toast
-import com.openai.client.OpenAIClient
-import com.openai.client.okhttp.OpenAIOkHttpClient
-import com.openai.models.responses.Response
-import com.openai.models.responses.ResponseCreateParams
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import io.github.patricksmill.quicknotes.model.note.Note
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.Executors
 
 /**
@@ -71,9 +74,7 @@ class AutoTaggingService(
         executor.execute {
             try {
                 val tagCsv = requestAiTags(note, limit, apiKey, existingTags)
-                val tagNames = tagCsv.split("\\s*,\\s*".toRegex())
-                    .filter { it.isNotBlank() }
-                    .map { it.trim() }
+                val tagNames = parseTagList(tagCsv)
                 
                 if (tagNames.isNotEmpty()) {
                     Log.d(TAG, "AI suggested tags: $tagNames")
@@ -114,9 +115,7 @@ class AutoTaggingService(
         executor.execute {
             try {
                 val tagCsv = requestAiTags(note, limit, apiKey, existingTags)
-                val tagNames = tagCsv.split("\\s*,\\s*".toRegex())
-                    .filter { it.isNotBlank() }
-                    .map { it.trim() }
+                val tagNames = parseTagList(tagCsv)
                 
                 uiHandler.post { callback.onSuggestions(tagNames) }
             } catch (e: Exception) {
@@ -217,53 +216,45 @@ class AutoTaggingService(
         apiKey: String?,
         existingTags: Set<String>
     ): String {
-        val client = OpenAIOkHttpClient.builder()
-            .apiKey(apiKey.toString())
-            .build()
-
-        val prompt = buildAiPrompt(note, limit, existingTags)
-
-        // Resolve model dynamically: if settings uses "auto", fetch first chat model from OpenAI; otherwise honor selected key
         val settings = TagSettingsManager(ctx)
-        val key = settings.selectedAiModelKey
-
-        val modelId = if (key.equals("auto", ignoreCase = true)) {
-            try {
-                // Fetch models and pick a viable chat model id
-                val ids = fetchChatModelIds(client)
-                if (ids.isEmpty()) "gpt-4o-mini" else ids[0]
-            } catch (_: Exception) {
-                "gpt-4o-mini"
-            }
-        } else {
-            key
+        val config = settings.currentConfiguration()
+        val effectiveApiKey = apiKey?.takeIf { it.isNotBlank() } ?: config.apiKey
+        val prompt = buildAiPrompt(note, limit, existingTags)
+        if (effectiveApiKey.isNullOrBlank()) {
+            throw IllegalStateException("Missing API key for ${config.provider.displayName}")
         }
 
-        val params = ResponseCreateParams.builder()
-            .input(prompt)
-            .model(modelId)
-            .build()
+        val response = when (config.provider) {
+            TagSettingsManager.AiProvider.OPENAI,
+            TagSettingsManager.AiProvider.CUSTOM -> requestOpenAiResponses(
+                endpoint = config.endpoint,
+                apiKey = effectiveApiKey,
+                model = config.model,
+                prompt = prompt
+            )
 
-        val response = client.responses().create(params)
-        return extractResponseText(response)
-    }
+            TagSettingsManager.AiProvider.ANTHROPIC -> requestAnthropicMessages(
+                endpoint = config.endpoint,
+                apiKey = effectiveApiKey,
+                model = config.model,
+                prompt = prompt
+            )
 
-    // Fetch list of available chat-capable model ids from OpenAI client
-    private fun fetchChatModelIds(client: OpenAIClient): List<String> {
-        val ids = mutableListOf<String>()
-        try {
-            // New OpenAI SDK: list models via client.models().list()
-            val list = client.models().list()
-            for (m in list.data()) {
-                val id = m.id()
-                if (id.startsWith("gpt-") || id.contains("chat")) {
-                    ids.add(id)
-                }
-            }
-        } catch (_: Exception) {
-            // Ignore errors ;)
+            TagSettingsManager.AiProvider.GOOGLE -> requestOpenAiChatCompletions(
+                endpoint = config.endpoint,
+                apiKey = effectiveApiKey,
+                model = config.model,
+                prompt = prompt
+            )
         }
-        return ids
+
+        return when (config.provider) {
+            TagSettingsManager.AiProvider.OPENAI,
+            TagSettingsManager.AiProvider.CUSTOM -> extractOpenAiResponsesText(response)
+
+            TagSettingsManager.AiProvider.ANTHROPIC -> extractAnthropicText(response)
+            TagSettingsManager.AiProvider.GOOGLE -> extractOpenAiChatText(response)
+        }
     }
 
     /**
@@ -280,33 +271,174 @@ class AutoTaggingService(
         existingTags: Set<String>
     ): String {
         return buildString {
-            appendLine("system: You are a tag suggestion assistant that outputs a comma-separated list of tag names.")
+            appendLine("You are a tag suggestion assistant that outputs a comma-separated list of tag names.")
             appendLine("Use existing tags when appropriate. Do not explain or output anything other than the tag list.")
             appendLine("Existing tags: ${existingTags.joinToString(", ")}")
-            appendLine("user: Extract up to $limit tags from the following text:")
+            appendLine("Extract up to $limit tags from the following text:")
             appendLine("Title: ${note.title}")
             appendLine("Content: ${note.content}")
         }
     }
 
-    /**
-     * Extracts text from OpenAI API response.
-     *
-     * @param response The API response
-     * @return Extracted text content
-     */
-    private fun extractResponseText(response: Response): String {
-        val sb = StringBuilder()
-        for (item in response.output()) {
-            if (!item.isMessage()) continue
+    private fun parseTagList(raw: String): List<String> {
+        return raw.split(Regex("[,\\n]"))
+            .map { it.trim() }
+            .map { it.replace(Regex("^\\s*[-*•\\d.]+\\s*"), "") }
+            .map { it.trim('"', '\'') }
+            .filter { it.isNotBlank() }
+    }
 
-            val msg = item.asMessage()
-            for (content in msg.content()) {
-                if (content.isOutputText()) {
-                    sb.append(content.asOutputText().text())
+    private fun requestOpenAiResponses(
+        endpoint: String,
+        apiKey: String,
+        model: String,
+        prompt: String
+    ): JsonObject {
+        val payload = JsonObject().apply {
+            addProperty("model", model)
+            addProperty("input", prompt)
+            addProperty("max_output_tokens", 128)
+        }
+        return postJson(
+            url = joinUrl(endpoint, "responses"),
+            headers = mapOf("Authorization" to "Bearer $apiKey"),
+            payload = payload
+        )
+    }
+
+    private fun requestOpenAiChatCompletions(
+        endpoint: String,
+        apiKey: String,
+        model: String,
+        prompt: String
+    ): JsonObject {
+        val messages = JsonArray().apply {
+            add(JsonObject().apply {
+                addProperty("role", "user")
+                addProperty("content", prompt)
+            })
+        }
+        val payload = JsonObject().apply {
+            addProperty("model", model)
+            add("messages", messages)
+            addProperty("temperature", 0.2)
+        }
+        return postJson(
+            url = joinUrl(endpoint, "chat/completions"),
+            headers = mapOf("Authorization" to "Bearer $apiKey"),
+            payload = payload
+        )
+    }
+
+    private fun requestAnthropicMessages(
+        endpoint: String,
+        apiKey: String,
+        model: String,
+        prompt: String
+    ): JsonObject {
+        val messages = JsonArray().apply {
+            add(JsonObject().apply {
+                addProperty("role", "user")
+                add("content", JsonArray().apply {
+                    add(JsonObject().apply {
+                        addProperty("type", "text")
+                        addProperty("text", prompt)
+                    })
+                })
+            })
+        }
+        val payload = JsonObject().apply {
+            addProperty("model", model)
+            addProperty("max_tokens", 128)
+            add("messages", messages)
+        }
+        return postJson(
+            url = joinUrl(endpoint, "messages"),
+            headers = mapOf(
+                "x-api-key" to apiKey,
+                "anthropic-version" to "2023-06-01"
+            ),
+            payload = payload
+        )
+    }
+
+    private fun postJson(
+        url: String,
+        headers: Map<String, String>,
+        payload: JsonObject
+    ): JsonObject {
+        val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+            requestMethod = "POST"
+            connectTimeout = 30_000
+            readTimeout = 30_000
+            doInput = true
+            doOutput = true
+            setRequestProperty("Content-Type", "application/json; charset=utf-8")
+            headers.forEach { (name, value) -> setRequestProperty(name, value) }
+        }
+
+        try {
+            connection.outputStream.use { output ->
+                output.write(payload.toString().toByteArray(StandardCharsets.UTF_8))
+            }
+
+            val code = connection.responseCode
+            val body = readBody(connection, code)
+            if (code !in 200..299) {
+                throw IllegalStateException("HTTP $code ${connection.responseMessage}: $body")
+            }
+
+            return JsonParser.parseString(body).asJsonObject
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun readBody(connection: HttpURLConnection, code: Int): String {
+        val stream = if (code in 200..299) connection.inputStream else connection.errorStream
+        if (stream == null) return ""
+        return InputStreamReader(stream, StandardCharsets.UTF_8).use { it.readText() }
+    }
+
+    private fun joinUrl(baseUrl: String, path: String): String {
+        val trimmed = baseUrl.trim().trimEnd('/')
+        val suffix = path.trimStart('/')
+        return "$trimmed/$suffix"
+    }
+
+    private fun extractOpenAiResponsesText(response: JsonObject): String {
+        val output = response.getAsJsonArray("output") ?: return ""
+        val sb = StringBuilder()
+        output.forEach { item ->
+            val itemObj = item.asJsonObject
+            if (itemObj.get("type")?.asString != "message") return@forEach
+            val content = itemObj.getAsJsonArray("content") ?: return@forEach
+            content.forEach { part ->
+                val partObj = part.asJsonObject
+                if (partObj.get("type")?.asString == "output_text") {
+                    sb.append(partObj.get("text")?.asString.orEmpty())
                 }
             }
-            break
+        }
+        return sb.toString().trim()
+    }
+
+    private fun extractOpenAiChatText(response: JsonObject): String {
+        val choices = response.getAsJsonArray("choices") ?: return ""
+        if (choices.size() == 0) return ""
+        val choice = choices[0].asJsonObject
+        val message = choice.getAsJsonObject("message") ?: return ""
+        return message.get("content")?.takeIf { !it.isJsonNull }?.asString.orEmpty().trim()
+    }
+
+    private fun extractAnthropicText(response: JsonObject): String {
+        val content = response.getAsJsonArray("content") ?: return ""
+        val sb = StringBuilder()
+        content.forEach { part ->
+            val partObj = part.asJsonObject
+            if (partObj.get("type")?.asString == "text") {
+                sb.append(partObj.get("text")?.asString.orEmpty())
+            }
         }
         return sb.toString().trim()
     }

--- a/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/AutoTaggingService.kt
+++ b/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/AutoTaggingService.kt
@@ -9,7 +9,6 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import io.github.patricksmill.quicknotes.model.note.Note
-import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.charset.StandardCharsets
@@ -392,18 +391,6 @@ class AutoTaggingService(
         } finally {
             connection.disconnect()
         }
-    }
-
-    private fun readBody(connection: HttpURLConnection, code: Int): String {
-        val stream = if (code in 200..299) connection.inputStream else connection.errorStream
-        if (stream == null) return ""
-        return InputStreamReader(stream, StandardCharsets.UTF_8).use { it.readText() }
-    }
-
-    private fun joinUrl(baseUrl: String, path: String): String {
-        val trimmed = baseUrl.trim().trimEnd('/')
-        val suffix = path.trimStart('/')
-        return "$trimmed/$suffix"
     }
 
     private fun extractOpenAiResponsesText(response: JsonObject): String {

--- a/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/TagHttpUtils.kt
+++ b/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/TagHttpUtils.kt
@@ -1,0 +1,17 @@
+package io.github.patricksmill.quicknotes.model.tag
+
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.nio.charset.StandardCharsets
+
+internal fun readBody(connection: HttpURLConnection, code: Int): String {
+    val stream = if (code in 200..299) connection.inputStream else connection.errorStream
+    if (stream == null) return ""
+    return InputStreamReader(stream, StandardCharsets.UTF_8).use { it.readText() }
+}
+
+internal fun joinUrl(baseUrl: String, path: String): String {
+    val trimmed = baseUrl.trim().trimEnd('/')
+    val suffix = path.trimStart('/')
+    return "$trimmed/$suffix"
+}

--- a/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/TagSettingsManager.kt
+++ b/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/TagSettingsManager.kt
@@ -9,82 +9,207 @@ import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import java.nio.charset.StandardCharsets
 import java.security.KeyStore
+import java.util.Locale
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 
 /**
- * TagSettingsManager handles tag-related preferences and configuration settings.
- * It provides access to user preferences for AI tagging, API keys, and tagging limits.
- * Uses Android Keystore with javax.crypto.KeyGenerator for secure API key storage.
+ * TagSettingsManager handles AI provider selection and the related credentials.
  */
 class TagSettingsManager(ctx: Context) {
-    private val preferences: SharedPreferences
-    val apiKey: String?
-        /**
-         * Gets the OpenAI API key. Migrates from legacy plaintext if present.
-         */
+    private val preferences: SharedPreferences =
+        PreferenceManager.getDefaultSharedPreferences(ctx.applicationContext)
+
+    enum class AiProvider(
+        val storageKey: String,
+        val displayName: String,
+        val defaultEndpoint: String,
+        val defaultModel: String
+    ) {
+        OPENAI(
+            "openai",
+            "OpenAI",
+            "https://api.openai.com/v1",
+            "gpt-5-mini"
+        ),
+        ANTHROPIC(
+            "anthropic",
+            "Claude",
+            "https://api.anthropic.com/v1",
+            "claude-sonnet-4-20250514"
+        ),
+        GOOGLE(
+            "google",
+            "Google",
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+            "gemini-2.5-flash"
+        ),
+        CUSTOM(
+            "custom",
+            "Custom",
+            "https://api.openai.com/v1",
+            "gpt-5-mini"
+        )
+    }
+
+    data class AiConfiguration(
+        val provider: AiProvider,
+        val apiKey: String?,
+        val endpoint: String,
+        val model: String
+    )
+
+    val selectedProvider: AiProvider
         get() {
-            val enc =
-                preferences.getString(PREF_API_KEY_ENCRYPTED, null)
-            if (enc != null && !enc.trim { it <= ' ' }.isEmpty()) {
-                val dec = decrypt(enc)
-                if (dec != null && !dec.trim { it <= ' ' }.isEmpty()) return dec
+            val stored = preferences.getString(PREF_AI_PROVIDER, null)
+            return when {
+                stored != null -> parseProvider(stored)
+                legacyCustomEndpoint().isNotBlank() && legacyCustomEndpoint() != AiProvider.OPENAI.defaultEndpoint -> AiProvider.CUSTOM
+                else -> AiProvider.OPENAI
             }
-            val legacy =
-                preferences.getString(PREF_API_KEY, null)
-            if (legacy != null && !legacy.trim { it <= ' ' }.isEmpty()) {
-                saveApiKey(legacy)
-                preferences.edit { remove(PREF_API_KEY) }
+        }
+
+    fun setSelectedProvider(provider: AiProvider) {
+        preferences.edit { putString(PREF_AI_PROVIDER, provider.storageKey) }
+    }
+
+    val apiKey: String?
+        get() = apiKeyFor(selectedProvider)
+
+    fun apiKeyFor(provider: AiProvider): String? {
+        val encrypted = preferences.getString(encryptedApiKeyKey(provider), null)
+        if (!encrypted.isNullOrBlank()) {
+            val decrypted = decrypt(encrypted)
+            if (!decrypted.isNullOrBlank()) {
+                return decrypted
+            }
+        }
+
+        if (provider == AiProvider.OPENAI) {
+            val legacy = preferences.getString(LEGACY_OPENAI_API_KEY, null)
+            if (!legacy.isNullOrBlank()) {
+                saveApiKey(provider, legacy)
+                preferences.edit { remove(LEGACY_OPENAI_API_KEY) }
                 return legacy
             }
-            return null
         }
 
-    /** Saves the API key encrypted with AES/GCM in Android Keystore.  */
-    fun saveApiKey(apiKey: String) {
-        val trimmed = apiKey.trim { it <= ' ' }
-        if (trimmed.isEmpty()) {
-            preferences.edit { remove(PREF_API_KEY_ENCRYPTED) }
+        if (provider == AiProvider.CUSTOM) {
+            val openAiKey = apiKeyFor(AiProvider.OPENAI)
+            if (!legacyCustomEndpoint().isBlank() && !openAiKey.isNullOrBlank()) {
+                return openAiKey
+            }
+        }
+
+        return null
+    }
+
+    fun saveApiKey(provider: AiProvider, apiKey: String) {
+        val trimmed = apiKey.trim()
+        val keyName = encryptedApiKeyKey(provider)
+
+        if (trimmed.isBlank()) {
+            preferences.edit { remove(keyName) }
             return
         }
+
         val enc = encrypt(trimmed)
         if (enc != null) {
-            preferences.edit { putString(PREF_API_KEY_ENCRYPTED, enc) }
+            preferences.edit { putString(keyName, enc) }
         }
     }
 
-    val isAiMode: Boolean
-        get() = preferences.getBoolean(
-            PREF_AI_AUTO_TAG,
-            DEFAULT_AI_MODE
-        )
-
-    fun setAiMode(enabled: Boolean) {
-        preferences.edit { putBoolean(PREF_AI_AUTO_TAG, enabled) }
+    fun saveApiKey(value: String) {
+        saveApiKey(selectedProvider, value)
     }
-    val autoTagLimit: Int
-        get() = preferences.getInt(
-            PREF_AUTO_TAG_LIMIT,
-            DEFAULT_AUTO_TAG_LIMIT
-        )
 
-    fun setAutoTagLimit(limit: Int) {
-        preferences.edit { putInt(PREF_AUTO_TAG_LIMIT, limit) }
+    val selectedAiEndpoint: String
+        get() = endpointFor(selectedProvider)
+
+    fun endpointFor(provider: AiProvider): String {
+        return when (provider) {
+            AiProvider.OPENAI -> AiProvider.OPENAI.defaultEndpoint
+            AiProvider.ANTHROPIC -> AiProvider.ANTHROPIC.defaultEndpoint
+            AiProvider.GOOGLE -> AiProvider.GOOGLE.defaultEndpoint
+            AiProvider.CUSTOM -> {
+                val endpoint = preferences.getString(CUSTOM_API_BASE_URL, null)
+                    .orEmpty()
+                    .trim()
+                if (endpoint.isBlank()) legacyCustomEndpoint().ifBlank { AiProvider.CUSTOM.defaultEndpoint } else endpoint
+            }
+        }
     }
+
+    fun setAiEndpoint(endpoint: String) {
+        saveCustomBaseUrl(endpoint)
+    }
+
+    fun saveCustomBaseUrl(endpoint: String) {
+        val trimmed = endpoint.trim()
+        if (trimmed.isBlank()) {
+            preferences.edit { remove(CUSTOM_API_BASE_URL) }
+        } else {
+            preferences.edit { putString(CUSTOM_API_BASE_URL, trimmed) }
+        }
+    }
+
     val selectedAiModelKey: String
-        get() = preferences.getString(
-            PREF_AI_MODEL,
-            DEFAULT_AI_MODEL
-        )!!
+        get() = modelFor(selectedProvider)
+
+    fun modelFor(provider: AiProvider): String {
+        val stored = when (provider) {
+            AiProvider.OPENAI -> preferences.getString(modelKey(provider), null)
+                ?: preferences.getString(LEGACY_CUSTOM_MODEL, null)
+            AiProvider.ANTHROPIC -> preferences.getString(modelKey(provider), null)
+            AiProvider.GOOGLE -> preferences.getString(modelKey(provider), null)
+            AiProvider.CUSTOM -> preferences.getString(CUSTOM_AI_MODEL, null)
+                ?: preferences.getString(LEGACY_CUSTOM_MODEL, null)
+        }
+
+        val trimmed = stored.orEmpty().trim()
+        return if (trimmed.isBlank() || trimmed.equals("auto", ignoreCase = true)) {
+            provider.defaultModel
+        } else {
+            trimmed
+        }
+    }
+
+    fun setAiModel(model: String) {
+        saveModel(selectedProvider, model)
+    }
+
+    fun saveModel(provider: AiProvider, model: String) {
+        val trimmed = model.trim()
+        val key = if (provider == AiProvider.CUSTOM) CUSTOM_AI_MODEL else modelKey(provider)
+        if (trimmed.isBlank()) {
+            preferences.edit { remove(key) }
+        } else {
+            preferences.edit { putString(key, trimmed) }
+        }
+    }
 
     val isAiTaggingConfigured: Boolean
         get() = this.isAiMode && hasValidApiKey()
 
     fun hasValidApiKey(): Boolean {
         val k = this.apiKey
-        return k != null && !k.trim { it <= ' ' }.isEmpty()
+        return !k.isNullOrBlank()
+    }
+
+    val isAiMode: Boolean
+        get() = preferences.getBoolean(PREF_AI_AUTO_TAG, DEFAULT_AI_MODE)
+
+    fun setAiMode(enabled: Boolean) {
+        preferences.edit { putBoolean(PREF_AI_AUTO_TAG, enabled) }
+    }
+
+    val autoTagLimit: Int
+        get() = preferences.getInt(PREF_AUTO_TAG_LIMIT, DEFAULT_AUTO_TAG_LIMIT)
+
+    fun setAutoTagLimit(limit: Int) {
+        preferences.edit { putInt(PREF_AUTO_TAG_LIMIT, limit) }
     }
 
     val isAiConfirmationEnabled: Boolean
@@ -95,63 +220,89 @@ class TagSettingsManager(ctx: Context) {
     }
 
     init {
-        val ctx1 = ctx.applicationContext
-        this.preferences = PreferenceManager.getDefaultSharedPreferences(ctx1)
+        // Ensure legacy plaintext keys are folded into encrypted storage early.
+        apiKeyFor(AiProvider.OPENAI)
+    }
+
+    private fun encryptedApiKeyKey(provider: AiProvider): String {
+        return when (provider) {
+            AiProvider.OPENAI -> OPENAI_API_KEY_ENCRYPTED
+            AiProvider.ANTHROPIC -> ANTHROPIC_API_KEY_ENCRYPTED
+            AiProvider.GOOGLE -> GOOGLE_API_KEY_ENCRYPTED
+            AiProvider.CUSTOM -> CUSTOM_API_KEY_ENCRYPTED
+        }
+    }
+
+    private fun modelKey(provider: AiProvider): String {
+        return when (provider) {
+            AiProvider.OPENAI -> OPENAI_AI_MODEL
+            AiProvider.ANTHROPIC -> ANTHROPIC_AI_MODEL
+            AiProvider.GOOGLE -> GOOGLE_AI_MODEL
+            AiProvider.CUSTOM -> CUSTOM_AI_MODEL
+        }
+    }
+
+    private fun legacyCustomEndpoint(): String {
+        return preferences.getString(LEGACY_CUSTOM_API_BASE_URL, null).orEmpty().trim()
+    }
+
+    private fun parseProvider(value: String): AiProvider {
+        return when (value.lowercase(Locale.US)) {
+            AiProvider.ANTHROPIC.storageKey -> AiProvider.ANTHROPIC
+            AiProvider.GOOGLE.storageKey -> AiProvider.GOOGLE
+            AiProvider.CUSTOM.storageKey -> AiProvider.CUSTOM
+            else -> AiProvider.OPENAI
+        }
     }
 
     private val orCreateSecretKey: SecretKey?
         get() {
-            try {
-                val ks =
-                    KeyStore.getInstance(ANDROID_KEYSTORE)
+            return try {
+                val ks = KeyStore.getInstance(ANDROID_KEYSTORE)
                 ks.load(null)
                 if (ks.containsAlias(KEY_ALIAS)) {
-                    val entry = ks.getEntry(
+                    val entry = ks.getEntry(KEY_ALIAS, null) as KeyStore.SecretKeyEntry
+                    entry.secretKey
+                } else {
+                    val keyGen = KeyGenerator.getInstance(
+                        KeyProperties.KEY_ALGORITHM_AES,
+                        ANDROID_KEYSTORE
+                    )
+                    val spec = KeyGenParameterSpec.Builder(
                         KEY_ALIAS,
-                        null
-                    ) as KeyStore.SecretKeyEntry
-                    return entry.secretKey
+                        KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                    )
+                        .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                        .setKeySize(256)
+                        .build()
+                    keyGen.init(spec)
+                    keyGen.generateKey()
                 }
-                val keyGen: KeyGenerator = KeyGenerator.getInstance(
-                    KeyProperties.KEY_ALGORITHM_AES,
-                    ANDROID_KEYSTORE
-                )
-                val spec = KeyGenParameterSpec.Builder(
-                    KEY_ALIAS,
-                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-                )
-                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                    .setKeySize(256)
-                    .build()
-                keyGen.init(spec)
-                return keyGen.generateKey()
             } catch (_: Exception) {
-                return null
+                null
             }
         }
 
     private fun encrypt(plaintext: String): String? {
-        try {
-            val key = this.orCreateSecretKey
-            if (key == null) return null
+        return try {
+            val key = orCreateSecretKey ?: return null
             val cipher = Cipher.getInstance("AES/GCM/NoPadding")
             cipher.init(Cipher.ENCRYPT_MODE, key)
-            val iv = cipher.iv // 12 bytes
+            val iv = cipher.iv
             val cipherBytes = cipher.doFinal(plaintext.toByteArray(StandardCharsets.UTF_8))
             val out = ByteArray(12 + cipherBytes.size)
             System.arraycopy(iv, 0, out, 0, 12)
             System.arraycopy(cipherBytes, 0, out, 12, cipherBytes.size)
-            return Base64.encodeToString(out, Base64.NO_WRAP)
+            Base64.encodeToString(out, Base64.NO_WRAP)
         } catch (_: Exception) {
-            return null
+            null
         }
     }
 
     private fun decrypt(base64: String?): String? {
-        try {
-            val key = this.orCreateSecretKey
-            if (key == null) return null
+        return try {
+            val key = orCreateSecretKey ?: return null
             val all = Base64.decode(base64, Base64.NO_WRAP)
             if (all.size < 13) return null
             val iv = ByteArray(12)
@@ -159,35 +310,59 @@ class TagSettingsManager(ctx: Context) {
             val cipherBytes = ByteArray(all.size - 12)
             System.arraycopy(all, 12, cipherBytes, 0, cipherBytes.size)
             val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-            val gcm = GCMParameterSpec(128, iv)
-            cipher.init(Cipher.DECRYPT_MODE, key, gcm)
-            val plain = cipher.doFinal(cipherBytes)
-            return String(plain, StandardCharsets.UTF_8)
+            cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(128, iv))
+            String(cipher.doFinal(cipherBytes), StandardCharsets.UTF_8)
         } catch (_: Exception) {
-            return null
+            null
         }
     }
 
     companion object {
-        private const val PREF_API_KEY = "openai_api_key" // legacy plaintext (migrated on read)
-        private const val PREF_API_KEY_ENCRYPTED = "openai_api_key_encrypted"
+        fun providerDisplayName(provider: AiProvider): String = provider.displayName
+
+        fun providerForStorageKey(storageKey: String): AiProvider {
+            return when (storageKey.lowercase(Locale.US)) {
+                AiProvider.ANTHROPIC.storageKey -> AiProvider.ANTHROPIC
+                AiProvider.GOOGLE.storageKey -> AiProvider.GOOGLE
+                AiProvider.CUSTOM.storageKey -> AiProvider.CUSTOM
+                else -> AiProvider.OPENAI
+            }
+        }
+
+        private const val PREF_AI_PROVIDER = "pref_ai_provider"
         private const val PREF_AI_AUTO_TAG = "pref_ai_auto_tag"
-        private const val PREF_AI_MODEL = "pref_ai_model"
         private const val PREF_AUTO_TAG_LIMIT = "auto_tag_limit"
         private const val PREF_AI_CONFIRM = "pref_ai_confirm"
 
-        // Default values
+        private const val OPENAI_API_KEY_ENCRYPTED = "openai_api_key_encrypted"
+        private const val ANTHROPIC_API_KEY_ENCRYPTED = "anthropic_api_key_encrypted"
+        private const val GOOGLE_API_KEY_ENCRYPTED = "google_api_key_encrypted"
+        private const val CUSTOM_API_KEY_ENCRYPTED = "custom_api_key_encrypted"
+
+        private const val OPENAI_AI_MODEL = "openai_ai_model"
+        private const val ANTHROPIC_AI_MODEL = "anthropic_ai_model"
+        private const val GOOGLE_AI_MODEL = "google_ai_model"
+        private const val CUSTOM_AI_MODEL = "custom_ai_model"
+
+        private const val CUSTOM_API_BASE_URL = "custom_api_base_url"
+
+        private const val LEGACY_OPENAI_API_KEY = "openai_api_key"
+        private const val LEGACY_CUSTOM_API_BASE_URL = "openai_api_base_url"
+        private const val LEGACY_CUSTOM_MODEL = "pref_ai_model"
+
         private const val DEFAULT_AUTO_TAG_LIMIT = 3
         private const val DEFAULT_AI_MODE = false
-        private const val DEFAULT_AI_MODEL = "gpt-4o-mini"
 
-        // ===== Encryption helpers (Android Keystore AES/GCM) =====
         private const val ANDROID_KEYSTORE = "AndroidKeyStore"
         private const val KEY_ALIAS = "quicknotes_api_key_aes"
     }
 
-    // Convenience wrapper to align with SettingsFragment usage
-    fun setApiKey(value: String) {
-        saveApiKey(value)
+    fun currentConfiguration(): AiConfiguration {
+        return AiConfiguration(
+            provider = selectedProvider,
+            apiKey = apiKey,
+            endpoint = selectedAiEndpoint,
+            model = selectedAiModelKey
+        )
     }
 }

--- a/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/TagSettingsManager.kt
+++ b/app/src/main/java/io/github/patricksmill/quicknotes/model/tag/TagSettingsManager.kt
@@ -247,12 +247,7 @@ class TagSettingsManager(ctx: Context) {
     }
 
     private fun parseProvider(value: String): AiProvider {
-        return when (value.lowercase(Locale.US)) {
-            AiProvider.ANTHROPIC.storageKey -> AiProvider.ANTHROPIC
-            AiProvider.GOOGLE.storageKey -> AiProvider.GOOGLE
-            AiProvider.CUSTOM.storageKey -> AiProvider.CUSTOM
-            else -> AiProvider.OPENAI
-        }
+        return providerForStorageKey(value)
     }
 
     private val orCreateSecretKey: SecretKey?

--- a/app/src/main/java/io/github/patricksmill/quicknotes/view/SettingsFragment.kt
+++ b/app/src/main/java/io/github/patricksmill/quicknotes/view/SettingsFragment.kt
@@ -228,14 +228,17 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private fun refreshModelSuggestionsFromApi() {
         val provider = tagSettingsManager.selectedProvider
         val apiKey = tagSettingsManager.apiKeyFor(provider)
+        val toastContext = context?.applicationContext
 
         if (apiKey.isNullOrBlank()) {
-            aiSettingsHandler.post {
-                Toast.makeText(
-                    requireContext(),
-                    "Add an API key to refresh live model suggestions.",
-                    Toast.LENGTH_SHORT
-                ).show()
+            if (toastContext != null) {
+                aiSettingsHandler.post {
+                    Toast.makeText(
+                        toastContext,
+                        "Add an API key to refresh live model suggestions.",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
             }
             return
         }
@@ -252,6 +255,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 }
 
                 aiSettingsHandler.post {
+                    val currentContext = context?.applicationContext ?: return@post
                     if (provider == tagSettingsManager.selectedProvider) {
                         currentModelSuggestions = modelCatalog.mergedSuggestions(
                             provider = provider,
@@ -262,7 +266,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                     }
 
                     Toast.makeText(
-                        requireContext(),
+                        currentContext,
                         if (fetched.isEmpty()) {
                             "No additional models were returned."
                         } else {
@@ -273,8 +277,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 }
             } catch (e: Exception) {
                 aiSettingsHandler.post {
+                    val currentContext = context?.applicationContext ?: return@post
                     Toast.makeText(
-                        requireContext(),
+                        currentContext,
                         "Could not refresh models: ${e.message}",
                         Toast.LENGTH_LONG
                     ).show()

--- a/app/src/main/java/io/github/patricksmill/quicknotes/view/SettingsFragment.kt
+++ b/app/src/main/java/io/github/patricksmill/quicknotes/view/SettingsFragment.kt
@@ -1,21 +1,46 @@
 package io.github.patricksmill.quicknotes.view
 
+import android.content.SharedPreferences
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.widget.Toast
 import androidx.preference.EditTextPreference
+import androidx.preference.ListPreference
 import androidx.preference.Preference
+import androidx.preference.PreferenceDataStore
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SeekBarPreference
 import androidx.preference.SwitchPreferenceCompat
+import androidx.preference.PreferenceManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.github.patricksmill.quicknotes.R
+import io.github.patricksmill.quicknotes.model.tag.AiModelCatalog
 import io.github.patricksmill.quicknotes.model.tag.TagSettingsManager
+import java.util.concurrent.Executors
 
 class SettingsFragment : PreferenceFragmentCompat() {
     private lateinit var tagSettingsManager: TagSettingsManager
+    private lateinit var providerDataStore: ProviderAwarePreferenceDataStore
+    private lateinit var modelCatalog: AiModelCatalog
+    private val aiSettingsHandler = Handler(Looper.getMainLooper())
+    private val aiSettingsExecutor = Executors.newSingleThreadExecutor()
+    private var currentModelSuggestions: List<AiModelCatalog.ModelOption> = emptyList()
+
+    override fun onDestroy() {
+        aiSettingsExecutor.shutdownNow()
+        super.onDestroy()
+    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
-        setPreferencesFromResource(R.xml.root_preferences, rootKey)
         tagSettingsManager = TagSettingsManager(requireContext())
+        modelCatalog = AiModelCatalog(requireContext())
+        providerDataStore = ProviderAwarePreferenceDataStore(
+            tagSettingsManager,
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+        )
+        preferenceManager.preferenceDataStore = providerDataStore
+        setPreferencesFromResource(R.xml.root_preferences, rootKey)
 
         setupVersionPref()
         setupDeleteAllPref()
@@ -67,6 +92,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupAiPrefs() {
+        val providerPref = findPreference<ListPreference>("pref_ai_provider")
         val autoTagLimitPref = findPreference<SeekBarPreference>("auto_tag_limit")
         autoTagLimitPref?.summary = tagSettingsManager.autoTagLimit.toString()
         autoTagLimitPref?.setOnPreferenceChangeListener { _, newValue ->
@@ -90,11 +116,238 @@ class SettingsFragment : PreferenceFragmentCompat() {
             true
         }
 
-
-        val apiKeyPref = findPreference<EditTextPreference>("openai_api_key")
+        val apiKeyPref = findPreference<EditTextPreference>("pref_ai_api_key")
         apiKeyPref?.setOnPreferenceChangeListener { _, newValue ->
-            tagSettingsManager.setApiKey(newValue as String)
+            tagSettingsManager.saveApiKey(newValue as String)
+            loadModelSuggestions()
+            if (!tagSettingsManager.apiKey.isNullOrBlank()) {
+                refreshModelSuggestionsFromApi()
+            }
             true
+        }
+
+        val modelPref = findPreference<EditTextPreference>("pref_ai_model")
+        modelPref?.setOnPreferenceChangeListener { _, newValue ->
+            tagSettingsManager.setAiModel(newValue as String)
+            loadModelSuggestions()
+            true
+        }
+
+        val modelSuggestionsPref = findPreference<Preference>("pref_ai_model_suggestions")
+        modelSuggestionsPref?.setOnPreferenceClickListener {
+            showModelSuggestionsDialog()
+            true
+        }
+
+        val endpointPref = findPreference<EditTextPreference>("pref_ai_base_url")
+        endpointPref?.setOnPreferenceChangeListener { _, newValue ->
+            val endpoint = newValue as String
+            tagSettingsManager.setAiEndpoint(endpoint)
+            loadModelSuggestions()
+            refreshModelSuggestionsFromApi()
+            true
+        }
+
+        providerPref?.setOnPreferenceChangeListener { _, newValue ->
+            tagSettingsManager.setSelectedProvider(
+                TagSettingsManager.providerForStorageKey(newValue as String)
+            )
+            loadModelSuggestions()
+            refreshModelSuggestionsFromApi()
+            true
+        }
+
+        loadModelSuggestions()
+    }
+
+    private fun refreshAiPreferenceLabels() {
+        val provider = tagSettingsManager.selectedProvider
+        val providerName = TagSettingsManager.providerDisplayName(provider)
+
+        findPreference<ListPreference>("pref_ai_provider")?.summary = providerName
+
+        findPreference<EditTextPreference>("pref_ai_api_key")?.apply {
+            title = "$providerName API Key"
+            summary = if (tagSettingsManager.apiKey.isNullOrBlank()) "Not set" else "Saved"
+        }
+
+        findPreference<EditTextPreference>("pref_ai_model")?.apply {
+            title = "$providerName Model"
+            summary = tagSettingsManager.selectedAiModelKey
+        }
+
+        findPreference<Preference>("pref_ai_model_suggestions")?.apply {
+            isVisible = true
+            summary = formatModelSuggestionSummary(currentModelSuggestions, provider)
+        }
+
+        findPreference<EditTextPreference>("pref_ai_base_url")?.apply {
+            isVisible = provider == TagSettingsManager.AiProvider.CUSTOM
+            summary = tagSettingsManager.selectedAiEndpoint
+        }
+    }
+
+    private fun loadModelSuggestions() {
+        val provider = tagSettingsManager.selectedProvider
+        val currentModel = tagSettingsManager.selectedAiModelKey
+        currentModelSuggestions = modelCatalog.mergedSuggestions(provider, currentModel)
+        refreshAiPreferenceLabels()
+    }
+
+    private fun showModelSuggestionsDialog() {
+        val provider = tagSettingsManager.selectedProvider
+        val options = if (currentModelSuggestions.isNotEmpty()) {
+            currentModelSuggestions
+        } else {
+            modelCatalog.mergedSuggestions(provider, tagSettingsManager.selectedAiModelKey)
+        }
+
+        if (options.isEmpty()) {
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle("Model Library")
+                .setMessage("No built-in models are available yet. Enter a model manually below.")
+                .setPositiveButton("OK", null)
+                .show()
+            return
+        }
+
+        val labels = options.map { it.label }.toTypedArray()
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle("Model Library")
+            .setItems(labels) { _, which ->
+                tagSettingsManager.setAiModel(options[which].id)
+                loadModelSuggestions()
+            }
+            .setNeutralButton("Refresh from API") { _, _ ->
+                refreshModelSuggestionsFromApi()
+            }
+            .setNegativeButton("Close", null)
+            .show()
+    }
+
+    private fun refreshModelSuggestionsFromApi() {
+        val provider = tagSettingsManager.selectedProvider
+        val apiKey = tagSettingsManager.apiKeyFor(provider)
+
+        if (apiKey.isNullOrBlank()) {
+            aiSettingsHandler.post {
+                Toast.makeText(
+                    requireContext(),
+                    "Add an API key to refresh live model suggestions.",
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+            return
+        }
+
+        aiSettingsExecutor.execute {
+            try {
+                val fetched = modelCatalog.fetchSuggestions(
+                    provider = provider,
+                    endpoint = tagSettingsManager.endpointFor(provider),
+                    apiKey = apiKey
+                )
+                if (fetched.isNotEmpty()) {
+                    modelCatalog.saveCachedSuggestions(provider, fetched)
+                }
+
+                aiSettingsHandler.post {
+                    if (provider == tagSettingsManager.selectedProvider) {
+                        currentModelSuggestions = modelCatalog.mergedSuggestions(
+                            provider = provider,
+                            currentModel = tagSettingsManager.selectedAiModelKey,
+                            liveSuggestions = fetched
+                        )
+                        refreshAiPreferenceLabels()
+                    }
+
+                    Toast.makeText(
+                        requireContext(),
+                        if (fetched.isEmpty()) {
+                            "No additional models were returned."
+                        } else {
+                            "Model suggestions updated from the API."
+                        },
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            } catch (e: Exception) {
+                aiSettingsHandler.post {
+                    Toast.makeText(
+                        requireContext(),
+                        "Could not refresh models: ${e.message}",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
+        }
+    }
+
+    private fun formatModelSuggestionSummary(
+        suggestions: List<AiModelCatalog.ModelOption>,
+        provider: TagSettingsManager.AiProvider
+    ): String {
+        if (suggestions.isEmpty()) {
+            return "Curated models available"
+        }
+
+        val preview = suggestions.take(3).joinToString(", ") { it.label }
+        return if (suggestions.size > 3) {
+            "$preview..."
+        } else {
+            preview
+        } + " for ${TagSettingsManager.providerDisplayName(provider)}"
+    }
+
+    private class ProviderAwarePreferenceDataStore(
+        private val settings: TagSettingsManager,
+        private val sharedPreferences: SharedPreferences
+    ) : PreferenceDataStore() {
+        override fun putString(key: String?, value: String?) {
+            when (key) {
+                "pref_ai_provider" -> {
+                    if (!value.isNullOrBlank()) {
+                        settings.setSelectedProvider(
+                            TagSettingsManager.providerForStorageKey(value)
+                        )
+                    }
+                }
+                "pref_ai_api_key" -> settings.saveApiKey(value.orEmpty())
+                "pref_ai_model" -> settings.setAiModel(value.orEmpty())
+                "pref_ai_base_url" -> settings.setAiEndpoint(value.orEmpty())
+                else -> if (key != null) sharedPreferences.edit().putString(key, value).apply()
+            }
+        }
+
+        override fun getString(key: String?, defValue: String?): String? {
+            return when (key) {
+                "pref_ai_provider" ->
+                    sharedPreferences.getString(key, null) ?: settings.selectedProvider.storageKey
+                "pref_ai_api_key" -> settings.apiKey.orEmpty()
+                "pref_ai_model" -> settings.selectedAiModelKey
+                "pref_ai_base_url" -> settings.selectedAiEndpoint
+                else -> sharedPreferences.getString(key, defValue)
+            }
+        }
+
+        override fun putBoolean(key: String?, value: Boolean) {
+            if (key != null) {
+                sharedPreferences.edit().putBoolean(key, value).apply()
+            }
+        }
+
+        override fun getBoolean(key: String?, defValue: Boolean): Boolean {
+            return if (key != null) sharedPreferences.getBoolean(key, defValue) else defValue
+        }
+
+        override fun putInt(key: String?, value: Int) {
+            if (key != null) {
+                sharedPreferences.edit().putInt(key, value).apply()
+            }
+        }
+
+        override fun getInt(key: String?, defValue: Int): Int {
+            return if (key != null) sharedPreferences.getInt(key, defValue) else defValue
         }
     }
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -43,4 +43,18 @@
         <item>@color/tag_color_grey</item>
         <item>@color/tag_color_blue_grey</item>
     </array>
+
+    <string-array name="ai_provider_entries">
+        <item>OpenAI</item>
+        <item>Claude</item>
+        <item>Google</item>
+        <item>Custom</item>
+    </string-array>
+
+    <string-array name="ai_provider_values">
+        <item>openai</item>
+        <item>anthropic</item>
+        <item>google</item>
+        <item>custom</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -30,6 +30,15 @@
         android:key="pref_category_AI"
         android:title="AI Features">
 
+        <ListPreference
+            android:key="pref_ai_provider"
+            android:title="AI Provider"
+            android:summary="OpenAI"
+            android:entries="@array/ai_provider_entries"
+            android:entryValues="@array/ai_provider_values"
+            android:defaultValue="openai"
+            android:icon="@drawable/ic_autotag" />
+
         <SwitchPreferenceCompat
             android:key="pref_ai_auto_tag"
             android:title="AI-powered Auto-Tagging"
@@ -46,12 +55,34 @@
             android:icon="@drawable/ic_check" />
 
         <EditTextPreference
-            android:key="openai_api_key"
-            android:title="OpenAI API Key"
-            android:summary="Required for AI features"
-            android:dialogTitle="Enter OpenAI API Key"
+            android:key="pref_ai_api_key"
+            android:title="API Key"
+            android:summary="Required for the selected provider"
+            android:dialogTitle="Enter API Key"
             android:inputType="textPassword"
             android:icon="@drawable/ic_key" />
+
+        <Preference
+            android:key="pref_ai_model_suggestions"
+            android:title="Model Library"
+            android:summary="Recommended models, plus live API refresh when available"
+            android:icon="@drawable/ic_autotag" />
+
+        <EditTextPreference
+            android:key="pref_ai_base_url"
+            android:title="Custom API Base URL"
+            android:summary="Only used for Custom"
+            android:dialogTitle="Enter Custom API Base URL"
+            android:inputType="textUri"
+            android:icon="@drawable/ic_key" />
+
+        <EditTextPreference
+            android:key="pref_ai_model"
+            android:title="Model"
+            android:summary="Model ID used for AI tagging"
+            android:dialogTitle="Enter model ID"
+            android:inputType="text"
+            android:icon="@drawable/ic_autotag" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
- Introduced support for multiple AI providers (OpenAI, Anthropic, Google, Custom) in the TagSettingsManager.
- Updated AutoTaggingService to handle requests and responses for different AI providers using JSON.
- Enhanced SettingsFragment to allow users to select AI provider, input API keys, and manage model settings.
- Added new preferences for API key, model selection, and custom API base URL in the settings UI.
- Implemented model suggestion fetching from the selected AI provider with live updates.
- Refactored existing code for better readability and maintainability, including encryption for API keys.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AI request/response codepaths, settings persistence, and encrypted credential storage; misconfiguration or API schema mismatches could break auto-tagging or model refresh across providers.
> 
> **Overview**
> Adds **multi-provider AI tagging** (OpenAI, Claude/Anthropic, Google, Custom) by extending `TagSettingsManager` with per-provider endpoint/model/key storage (encrypted) and legacy preference migration.
> 
> Replaces the OpenAI SDK usage in `AutoTaggingService` with provider-specific HTTP+JSON calls and more robust tag parsing, selecting the correct request/response format per provider.
> 
> Updates the settings UI (`root_preferences.xml` + `SettingsFragment`) to include an **AI Provider** picker, provider-specific API key/model labels, an optional custom base URL, and a **Model Library** that merges curated suggestions with cached/live results fetched from each provider’s models API; adds/updates instrumentation tests to cover provider switching, persistence, legacy migration, and curated model visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f869889bca62343981b1bf78252a761c1e005abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->